### PR TITLE
Filter PCAPotentialAddressMatch response by postcode type

### DIFF
--- a/lib/postcode_validation/gateway/pca_potential_address_match.rb
+++ b/lib/postcode_validation/gateway/pca_potential_address_match.rb
@@ -10,8 +10,8 @@ module PostcodeValidation
 
       def query(search_term:, country:)
         response = find_postcode(country, search_term)
-
-        response.map do |row|
+        postcode_matches = filter_by_postcodes(response)
+        postcode_matches.map do |row|
           raise PCARequestError, error_message(row) if row.key?('Error')
 
           PostcodeValidation::Domain::PotentialAddressMatch.new(text: row['Text'],
@@ -34,10 +34,13 @@ module PostcodeValidation
           query: {
             Key: KEY,
             Countries: country,
-            Text: search_term,
-            Filter: 'PostCode'
+            Text: search_term
           }
         }
+      end
+
+      def filter_by_postcodes(response)
+        response.select { |row| row['Type'] == 'Postcode' }
       end
     end
   end

--- a/lib/postcode_validation/gateway/pca_potential_address_match.rb
+++ b/lib/postcode_validation/gateway/pca_potential_address_match.rb
@@ -10,8 +10,8 @@ module PostcodeValidation
 
       def query(search_term:, country:)
         response = find_postcode(country, search_term)
-        postcode_matches = filter_by_postcodes(response)
-        postcode_matches.map do |row|
+
+        response.map do |row|
           raise PCARequestError, error_message(row) if row.key?('Error')
 
           PostcodeValidation::Domain::PotentialAddressMatch.new(text: row['Text'],
@@ -37,10 +37,6 @@ module PostcodeValidation
             Text: search_term
           }
         }
-      end
-
-      def filter_by_postcodes(response)
-        response.select { |row| row['Type'] != 'Address' }
       end
     end
   end

--- a/lib/postcode_validation/gateway/pca_potential_address_match.rb
+++ b/lib/postcode_validation/gateway/pca_potential_address_match.rb
@@ -40,7 +40,7 @@ module PostcodeValidation
       end
 
       def filter_by_postcodes(response)
-        response.select { |row| row['Type'] == 'Postcode' }
+        response.select { |row| row['Type'] != 'Address' }
       end
     end
   end

--- a/lib/postcode_validation/use_case/validate_address.rb
+++ b/lib/postcode_validation/use_case/validate_address.rb
@@ -32,6 +32,8 @@ module PostcodeValidation
         result.each do |address|
           return { valid?: true, reason: ['valid_postcode'] } if address.postcode_matches? postcode
         end
+
+        { valid?: false, reason: ['no_postcode_matches_found'] }
       end
 
       def on_error(e)

--- a/spec/cassettes/PCA-address-invalid-request.yml
+++ b/spec/cassettes/PCA-address-invalid-request.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://services.postcodeanywhere.co.uk/Capture/Interactive/Find/v1.00/json.ws?Countries=UK&Filter=PostCode&Key=FAKEKEY&Text=SE1%200SW
+    uri: https://services.postcodeanywhere.co.uk/Capture/Interactive/Find/v1.00/json.ws?Countries=UK&Key=FAKEKEY&Text=SE1%200SW
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
       string: "[{\"Error\":\"1002\",\"Description\":\"Text or Container Invalid\",\"Cause\":\"The
         Text or Container parameter was not recognised.\",\"Resolution\":\"Check the
         documentation for valid options.\"}]\r\n"
-    http_version: 
+    http_version:
   recorded_at: Tue, 06 Dec 2016 12:16:40 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/PCA-address-matching.yml
+++ b/spec/cassettes/PCA-address-matching.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://services.postcodeanywhere.co.uk/Capture/Interactive/Find/v1.00/json.ws?Countries=GB&Filter=PostCode&Key=FAKEKEY&Text=SE1%200SW
+    uri: https://services.postcodeanywhere.co.uk/Capture/Interactive/Find/v1.00/json.ws?Countries=GB&Key=FAKEKEY&Text=SE1%200SW
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
       string: "[{\"Id\":\"GB|RM|A|P-SE1-0SW\",\"Type\":\"Postcode\",\"Text\":\"SE1
         0SW\",\"Highlight\":\"0-1,1-2,2-3,4-5,5-6,6-7;0-1\",\"Description\":\"Southwark
         Street, London - 45 Addresses\"}]\r\n"
-    http_version: 
+    http_version:
   recorded_at: Tue, 06 Dec 2016 12:16:39 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
PCA Capture Interactive find doesn't take a filter in the query but returns a 'Type' in the response so we can filter by this instead